### PR TITLE
Added missing ServiceProto enum

### DIFF
--- a/Texnomic.NMap.Schema/Enums/ServiceProto.cs
+++ b/Texnomic.NMap.Schema/Enums/ServiceProto.cs
@@ -1,0 +1,11 @@
+﻿using System.Xml.Serialization;
+
+namespace Texnomic.NMap.Schema.Enums
+{
+    [XmlType("ServiceProto")]
+    public enum ServiceProto
+    {
+        [XmlEnum("rpc")]
+        Rpc,
+    }
+}


### PR DESCRIPTION
As described in #1, this enum is missing. According to the full DTD ([https://nmap.org/book/nmap-dtd.html](url)), the only valid value is "rpc".